### PR TITLE
refactor: remove progress bar

### DIFF
--- a/templates/fullwide/app.js
+++ b/templates/fullwide/app.js
@@ -16,23 +16,6 @@ function trueWidth() {
   return browserWidth() * pixelRatio()
 }
 
-function scrolledTo(pos) {
-  var progress = document.getElementById('progress-inner')
-  var total = slides.length
-  var width = pos * 100 / total + '%'
-  progress.style.width = width
-}
-
-slides.forEach(function(id, i) {
-  var elem = document.getElementById(id)
-  if (!elem) return
-  
-  var watcher = scrollMonitor.create(elem)
-  watcher.enterViewport(function() {
-    scrolledTo(i + 1)
-  })
-})
-
 document.addEventListener('lazybeforeunveil', function(e) {
   // Lazy load responsive videos right before they're unveiled by lazysizes
   // This doesn't load larger versions when the window resizes
@@ -86,8 +69,6 @@ $.getJSON('metadata.json').done(function(metadata) {
     if (style) elem.style.cssText = style
   })
 })
-
-scrolledTo(1)
 
 $('.slide-desc').flowtype({
   minFont: 12,

--- a/templates/fullwide/index.html.jinja2
+++ b/templates/fullwide/index.html.jinja2
@@ -7,9 +7,6 @@
   <link rel="stylesheet" href="style.css">
 </head>
 <body>
-  <div id="progress-outer">
-    <div id="progress-inner"></div>
-  </div>
   {% for m in media %}
     <div id="slide_{{ loop.index }}" class="slide">
       <span id="slide_{{ loop.index }}_desc" class="slide-desc"></span>
@@ -27,17 +24,11 @@
   {% endfor %}
   
   <script src="https://cdnjs.cloudflare.com/ajax/libs/lazysizes/1.3.1/lazysizes.min.js"></script>
-  <script src="https://cdnjs.cloudflare.com/ajax/libs/scrollmonitor/1.0.12/scrollMonitor.min.js"></script>
   <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/markdown.js/0.5.0/markdown.min.js"></script>
   <script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/2.1.4/jquery.min.js"></script>
   <script src="https://cdnjs.cloudflare.com/ajax/libs/Flowtype.js/1.1.0/flowtype.min.js"></script>
 
   <script>
-    var slides = [
-      {% for m in media %}
-        'slide_{{ loop.index }}',
-      {% endfor %}
-    ]
     var slidesById = {
       {% for m in media %}
         '{{ m.name }}': 'slide_{{ loop.index }}',

--- a/templates/fullwide/style.css
+++ b/templates/fullwide/style.css
@@ -9,20 +9,6 @@ img, video {
   width: 100%;
 }
 
-#progress-outer {
-  position: fixed;
-  left: 0;
-  top: 0;
-  width: 100%;
-}
-
-#progress-inner {
-  height: 4px;
-  width: 20%;
-  background-color: #61c3f8;
-  transition-duration: 0.5s;
-}
-
 /* absolute positioning:
    https://css-tricks.com/absolute-positioning-inside-relative-positioning/ */
 .slide {


### PR DESCRIPTION
I'm not sure this was working as expected. As each slide fills its block, the
progress bar is hidden (it's only visible briefly as the first image loads).

I played around with margins, but actually found it detracted from the gallery's
aesthetics; with a full-width theme, the focus is purely on the images
themselves (and what drew me to Expose/expose.py in the first place).
