### PR TITLE
feature: runtime config

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,7 +83,6 @@ Copyright (c) 2015 Matthew Lewis. Licensed under [the MIT License](http://openso
 ## Code
 
 * Move JS deps into the app instead of running off cdnjs
-* Configurable, non-hard-coded config
 * Alternate source/output dirs
 
 ## Docs


### PR DESCRIPTION
Reads in a config file (`--config`, default: `.expose.yml`) and overrides the
named tuple defaults.

Example config:

``` yml
TEMPLATE: tlvince
IMAGE_PATTERNS:
  - '*.png'
```

Note, this reuses the current config keys (UPPER_CASE). It maybe better to
rename these to lower_case (or convert the config file's keys to upper case) for
convenience/friendliness.
